### PR TITLE
[BUGFIX] Widget: append() calls revalidate() so redraw() is needless

### DIFF
--- a/src/view/widget/Widget.js
+++ b/src/view/widget/Widget.js
@@ -176,7 +176,6 @@ define([
             if (this.getFlag(Widget.FLAG_REALIZED)) {
                 child.onAdded();
             }
-            child.redraw();
         },
 
         /**


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webida/graphite/24)

<!-- Reviewable:end -->
